### PR TITLE
🚀 Seperate generate and copy to clipboard buttons

### DIFF
--- a/public/scripts/script.js
+++ b/public/scripts/script.js
@@ -13,6 +13,7 @@ const theme = document.getElementById("theme")
 
 const url = document.getElementById("url")
 const image = document.getElementById("image")
+const generate = document.getElementById('generate');
 const link = document.getElementById("link")
 
 //url components
@@ -68,6 +69,11 @@ const genURL = () => {
     url.innerHTML = genURL()
   })
 })
+
+generate.addEventListener('click', () => {
+	let finalUrl = genURL();
+	image.src = finalUrl;
+});
 
 link.addEventListener("click", () => {
   let finalUrl = genURL()

--- a/public/styles/output.css
+++ b/public/styles/output.css
@@ -667,6 +667,10 @@ video {
   justify-content: space-between;
 }
 
+.gap-3 {
+  gap: 0.75rem;
+}
+
 .break-words {
   overflow-wrap: break-word;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -122,14 +122,31 @@
                 placeholder="Author">
             </div>
           </div>
+
           <div
-            class="md:flex flex-col justify-center items-center p-2 my-5 mx-2 md:mx-5 font-mono bg-zinc-800 rounded-xl text-center">
-            <p id="url" class="break-all flex items-center justify-center md:w-full text-center p-2"></p>
-            <div class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100" id="link">
-              <p class="break-words">🔗 Generate and copy link to clipboard</p>
-            </div>
-          </div>
-        </div>
+							class="md:flex flex-col justify-center items-center p-2 my-5 mx-2 md:mx-5 font-mono bg-zinc-800 rounded-xl text-center"
+						>
+							<p
+								id="url"
+								class="break-all flex items-center justify-center md:w-full text-center p-2"
+							></p>
+						</div>
+
+						<div class="flex gap-3 justify-center items-center">
+							<div
+								class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100"
+								id="generate"
+							>
+								<p class="break-words">🚀 Generate</p>
+							</div>
+
+							<div
+								class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100"
+								id="link"
+							>
+								<p class="break-words">🔗 Copy link to clipboard</p>
+							</div>
+						</div>
       </div>
     </section>
   </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -123,30 +123,20 @@
             </div>
           </div>
 
-          <div
-							class="md:flex flex-col justify-center items-center p-2 my-5 mx-2 md:mx-5 font-mono bg-zinc-800 rounded-xl text-center"
-						>
-							<p
-								id="url"
-								class="break-all flex items-center justify-center md:w-full text-center p-2"
-							></p>
+          <div class="md:flex flex-col justify-center items-center p-2 my-5 mx-2 md:mx-5 font-mono bg-zinc-800 rounded-xl text-center">
+						<p id="url" class="break-all flex items-center justify-center md:w-full text-center p-2"
+						></p>
+					</div>
+
+					<div class="flex gap-3 justify-center items-center">
+						<div class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100" id="generate">
+							<p class="break-words">🚀 Generate</p>
 						</div>
 
-						<div class="flex gap-3 justify-center items-center">
-							<div
-								class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100"
-								id="generate"
-							>
-								<p class="break-words">🚀 Generate</p>
-							</div>
-
-							<div
-								class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100"
-								id="link"
-							>
-								<p class="break-words">🔗 Copy link to clipboard</p>
-							</div>
+						<div class="bg-neutral-900 p-2 cursor-pointer rounded-xl transition-all ease-in-out duration-100" id="link">
+							<p class="break-words">🔗 Copy link to clipboard</p>
 						</div>
+					</div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
This PR fixes #9 

- `Generate` button will instantly view the image with the latest changes
- `Copy to clipboard` button will copy the image URL

Refer 👇

<img width="1215" alt="Capture" src="https://user-images.githubusercontent.com/50659234/184552052-63059527-be5d-4ced-baa4-ee16370fdf04.PNG">
 